### PR TITLE
Fixed "Chinese" translation problem and some more idiomatic translations

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -77,6 +77,6 @@ export const countries: { value: string; label: string }[] = [
 export const languages: { value: string; label: string }[] = [
     { value: 'fa', label: 'فارسی' },
     { value: 'en', label: 'English' },
-    { value: 'cn', label: '中国人' },
+    { value: 'cn', label: '中文' },
     { value: 'ru', label: 'Русский' }
 ];

--- a/src/locale/cn.json
+++ b/src/locale/cn.json
@@ -6,7 +6,7 @@
         "connected_confirm": "已连接",
         "disconnecting": "断开连接中...",
         "disconnected": "已断开连接",
-        "ip_check": "检查 IP..."
+        "ip_check": "检查 IP 中..."
     },
     "home": {
         "title_warp_based": "基于 Warp",
@@ -18,7 +18,7 @@
         "drawer_update_label": "新更新",
         "drawer_speed_test": "速度测试",
         "drawer_about": "关于应用",
-        "drawer_lang": "语言更改"
+        "drawer_lang": "更改语言"
     },
     "toast": {
         "ip_check_please_wait": "请等待几秒钟后重试检查！",
@@ -51,13 +51,13 @@
         "proxy_mode_desc": "定义代理设置",
         "port": "代理端口",
         "port_desc": "定义应用程序的代理端口",
-        "share_vpn": "共享（局域网）",
-        "share_vpn_desc": "在网络上共享代理",
+        "share_vpn": "共享代理",
+        "share_vpn_desc": "在局域网上共享代理",
         "dns": "更改 DNS",
         "dns_desc": "使用 Google 公共 DNS",
         "ip_data": "IP 检查",
         "ip_data_desc": "连接后显示 IP 和位置",
-        "dark_mode": "暗黑模式",
+        "dark_mode": "深色模式",
         "dark_mode_desc": "指定应用程序的显示模式",
         "lang": "语言",
         "lang_desc": "更改应用程序界面语言",


### PR DESCRIPTION
I noticed that the translation of "Chinese" in the [src/locale/cn.json](https://github.com/bepass-org/oblivion-desktop/blob/e6004021b5f4f2b3559752c7c50efbb811559d4a/src/locale/cn.json#L60) file is incorrect. It is currently translated as `中国人 (Chinese people)`, but it should be translated as `中文 (Chinese language)`.

I have updated the translation to the correct term, `中文`. And I modified some translations to make them more authentic and smooth.Please review the changes and merge the pull request if you agree.