### PR TITLE
fix gnome proxy set for http and https

### DIFF
--- a/src/main/lib/proxy.ts
+++ b/src/main/lib/proxy.ts
@@ -88,6 +88,8 @@ const enableGnomeProxy = async (ip: string, port: string, routingRules: any): Pr
     const proxySettings = {
         mode: 'manual',
         socks: `socks5://${ip}:${port}`,
+        https: `https://${ip}:${port}`,
+        http: `http://${ip}:${port}`,
         host: ip,
         port: port
     };
@@ -98,6 +100,14 @@ const enableGnomeProxy = async (ip: string, port: string, routingRules: any): Pr
         await execPromise(`gsettings set org.gnome.system.proxy.socks host ${proxySettings.host}`);
 
         await execPromise(`gsettings set org.gnome.system.proxy.socks port ${proxySettings.port}`);
+
+        await execPromise(`gsettings set org.gnome.system.proxy.http host ${proxySettings.host}`);
+
+        await execPromise(`gsettings set org.gnome.system.proxy.http port ${proxySettings.port}`);
+
+        await execPromise(`gsettings set org.gnome.system.proxy.https host ${proxySettings.port}`);
+
+        await execPromise(`gsettings set org.gnome.system.proxy.https port ${proxySettings.port}`);
 
         // https://wiki.archlinux.org/title/Proxy_server#Proxy_settings_on_GNOME3
         const normalizeRoutingRules = (rules: any) => {


### PR DESCRIPTION
i've fixed the issue with setting HTTP and HTTPS proxies in GNOME , so applications which uses HTTP or HTTPS can send things over proxy , (before this change only socks host configured as proxy)