### PR TITLE
feat: Enhance offline connection handling

### DIFF
--- a/src/renderer/pages/Landing/useLanding.ts
+++ b/src/renderer/pages/Landing/useLanding.ts
@@ -56,7 +56,7 @@ const useLanding = () => {
     const navigate = useNavigate();
 
     const onChange = useCallback(() => {
-        if (!navigator.onLine) {
+        if (!navigator.onLine && !isConnected) {
             //checkInternetToast(appLang?.toast?.offline);
             defaultToast(appLang?.toast?.offline, 'ONLINE_STATUS', 7000);
         } else {
@@ -168,6 +168,7 @@ const useLanding = () => {
             toast.remove('ONLINE_STATUS');
         } else {
             //checkInternetToast(appLang?.toast?.offline);
+            //ipcRenderer.sendMessage('wp-end');
             defaultToast(appLang?.toast?.offline, 'ONLINE_STATUS', 7000);
         }
     }, [appLang?.toast?.offline, online]);


### PR DESCRIPTION
Improve connection handling when user goes offline

- Enable disconnect option when user is offline but VPN is connected
- Add commented code for automatic disconnect on connection loss

Currently, the connection switch is disabled when offline, even if the VPN is connected. This change allows users to disconnect manually when they lose internet connection while the VPN is active. 

A commented line for auto-disconnect on connection loss is currently disabled to avoid kill-switch-like behavior. When enabled, it automatically disconnects the VPN, which won't reconnect when internet is restored. Consider implementing this as a configurable option in the app settings, allowing users to choose whether they want automatic disconnection or to stay connected for when internet returns.