### PR TITLE
Enhance ProfileModal with "Paste Active Endpoint" Button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1975,6 +1975,7 @@ html[data-bs-theme="dark"] .shimmer {
     border-radius: 3px;
     width: 75px;
     direction: ltr;
+    z-index: 3;
 }
 .contextMenu .menuItem {
     float: right;

--- a/src/localization/cn.ts
+++ b/src/localization/cn.ts
@@ -113,6 +113,7 @@ const chinese: Language = {
         endpoint_suggested: '建议',
         endpoint_latest: '最新的',
         endpoint_update: '接收建议的端点',
+        endpoint_paste: '粘贴活动端点',
         profile_title: '个人资料',
         profile_name: '标题',
         profile_endpoint: '端点',

--- a/src/localization/de.ts
+++ b/src/localization/de.ts
@@ -116,6 +116,7 @@ const deutsch: Language = {
         endpoint_suggested: 'Empfohlen',
         endpoint_latest: 'Neueste',
         endpoint_update: 'Empfohlene Endpunkte erhalten',
+        endpoint_paste: 'aktiven Endpunkt einfügen',
         profile_title: 'Profil',
         profile_name: 'Titel',
         profile_endpoint: 'Endpunkt',

--- a/src/localization/en.ts
+++ b/src/localization/en.ts
@@ -114,6 +114,7 @@ const english: Language = {
         endpoint_suggested: 'Suggested',
         endpoint_latest: 'Latest',
         endpoint_update: 'Receive suggested endpoints',
+        endpoint_paste: 'Paste active endpoint',
         profile_title: 'Profile',
         profile_name: 'Title',
         profile_endpoint: 'Endpoint',

--- a/src/localization/fa.ts
+++ b/src/localization/fa.ts
@@ -115,6 +115,7 @@ const persian: Language = {
         endpoint_suggested: 'پیشنهادی',
         endpoint_latest: 'اخیر',
         endpoint_update: 'دریافت اندپوینت‌های پیشنهادی',
+        endpoint_paste: 'جای‌گذاری اندپوینت فعال',
         profile_title: 'پروفایل',
         profile_name: 'عنوان',
         profile_endpoint: 'اندپوینت',

--- a/src/localization/fa.ts
+++ b/src/localization/fa.ts
@@ -115,7 +115,7 @@ const persian: Language = {
         endpoint_suggested: 'پیشنهادی',
         endpoint_latest: 'اخیر',
         endpoint_update: 'دریافت اندپوینت‌های پیشنهادی',
-        endpoint_paste: 'جای‌گذاری اندپوینت فعال',
+        endpoint_paste: 'جایگذاری اندپوینت فعال',
         profile_title: 'پروفایل',
         profile_name: 'عنوان',
         profile_endpoint: 'اندپوینت',

--- a/src/localization/ru.ts
+++ b/src/localization/ru.ts
@@ -115,6 +115,7 @@ const russian: Language = {
         endpoint_suggested: 'предложено',
         endpoint_latest: 'Последний',
         endpoint_update: 'Получить предложенные конечные точки',
+        endpoint_paste: 'вставить активный endpoint',
         profile_title: 'Профиль',
         profile_name: 'Название',
         profile_endpoint: 'Конечная точка',

--- a/src/localization/type.ts
+++ b/src/localization/type.ts
@@ -114,6 +114,7 @@ export interface Modal {
     endpoint_suggested: string;
     endpoint_latest: string;
     endpoint_update: string;
+    endpoint_paste: string;
     profile_title: string;
     profile_name: string;
     profile_endpoint: string;

--- a/src/renderer/components/Input/index.tsx
+++ b/src/renderer/components/Input/index.tsx
@@ -7,9 +7,10 @@ interface InputProps {
     onChange: (event: ChangeEvent<HTMLInputElement>) => void;
     tabIndex?: number;
     type?: string;
+    placeholder?: string;
 }
 
-const Input: FC<InputProps> = ({ id, onChange, value, tabIndex = 0, type = 'text' }) => {
+const Input: FC<InputProps> = ({ id, onChange, value, tabIndex = 0, type = 'text', placeholder='' }) => {
     const {
         contextMenuStyle,
         handleCloseContextMenu,
@@ -30,6 +31,7 @@ const Input: FC<InputProps> = ({ id, onChange, value, tabIndex = 0, type = 'text
                 className='form-control'
                 onChange={onChange}
                 onContextMenu={handleContextMenu}
+                placeholder={placeholder}
                 type={type}
             />
             {contextMenuStyle && (

--- a/src/renderer/components/Modal/Profile/index.tsx
+++ b/src/renderer/components/Modal/Profile/index.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import classNames from 'classnames';
 import useProfileModal from './useProfileModal';
 import { defaultSettings } from '../../../../defaultSettings';
+import Input from '../../Input';
 
 interface ProfileModalProps {
     title: string;
@@ -69,14 +70,14 @@ const ProfileModal: FC<ProfileModalProps> = ({
                                 setProfileName(e.target.value);
                             }}
                         />
-                        <input
-                            type='text'
-                            className='form-control'
-                            placeholder={appLang?.modal?.profile_endpoint}
+                        <Input
+                            id='modal_profile_input'
                             value={profileEndpoint}
                             onChange={(e) => {
                                 setProfileEndpoint(e.target.value);
                             }}
+                            type='text'
+                            placeholder={appLang?.modal?.profile_endpoint}
                         />
                         <div className='input-group-btn'>
                             <button

--- a/src/renderer/components/Modal/Profile/index.tsx
+++ b/src/renderer/components/Modal/Profile/index.tsx
@@ -7,10 +7,11 @@ interface ProfileModalProps {
     isOpen: boolean;
     onClose: () => void;
     profiles: any;
+    endpoint: string;
     setProfiles: (value: any) => void;
 }
 
-const ProfileModal: FC<ProfileModalProps> = ({ title, isOpen, onClose, profiles, setProfiles }) => {
+const ProfileModal: FC<ProfileModalProps> = ({ title, isOpen, onClose, profiles, endpoint, setProfiles }) => {
     const {
         appLang,
         handleCancelButtonClick,
@@ -45,7 +46,7 @@ const ProfileModal: FC<ProfileModalProps> = ({ title, isOpen, onClose, profiles,
             <div className='dialogBox'>
                 <div className='container'>
                     <div className='line'>
-                        <div className='miniLine' />
+                        <div className='miniLine'/>
                     </div>
                     <h3>{title}</h3>
                     <div className='input-group'>
@@ -121,7 +122,7 @@ const ProfileModal: FC<ProfileModalProps> = ({ title, isOpen, onClose, profiles,
                             </div>
                         </>
                     )}
-                    <div className='clearfix' />
+                    <div className='clearfix'/>
                     <div
                         className={classNames('btn', 'btn-cancel')}
                         onClick={isEditing ? cancelEdit : handleCancelButtonClick}
@@ -140,6 +141,14 @@ const ProfileModal: FC<ProfileModalProps> = ({ title, isOpen, onClose, profiles,
                     >
                         {appLang?.modal?.update}
                     </div>
+                    <i
+                        role='presentation'
+                        className='material-icons updater'
+                        title={appLang?.modal?.endpoint_paste}
+                        onClick={() => {setProfileEndpoint(endpoint);}}
+                    >
+                        &#xe14f;
+                    </i>
                 </div>
             </div>
         </div>

--- a/src/renderer/components/Modal/Profile/index.tsx
+++ b/src/renderer/components/Modal/Profile/index.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import classNames from 'classnames';
 import useProfileModal from './useProfileModal';
+import { defaultSettings } from '../../../../defaultSettings';
 
 interface ProfileModalProps {
     title: string;
@@ -11,7 +12,14 @@ interface ProfileModalProps {
     setProfiles: (value: any) => void;
 }
 
-const ProfileModal: FC<ProfileModalProps> = ({ title, isOpen, onClose, profiles, endpoint, setProfiles }) => {
+const ProfileModal: FC<ProfileModalProps> = ({
+    title,
+    isOpen,
+    onClose,
+    profiles,
+    endpoint,
+    setProfiles
+}) => {
     const {
         appLang,
         handleCancelButtonClick,
@@ -46,7 +54,7 @@ const ProfileModal: FC<ProfileModalProps> = ({ title, isOpen, onClose, profiles,
             <div className='dialogBox'>
                 <div className='container'>
                     <div className='line'>
-                        <div className='miniLine'/>
+                        <div className='miniLine' />
                     </div>
                     <h3>{title}</h3>
                     <div className='input-group'>
@@ -122,7 +130,7 @@ const ProfileModal: FC<ProfileModalProps> = ({ title, isOpen, onClose, profiles,
                             </div>
                         </>
                     )}
-                    <div className='clearfix'/>
+                    <div className='clearfix' />
                     <div
                         className={classNames('btn', 'btn-cancel')}
                         onClick={isEditing ? cancelEdit : handleCancelButtonClick}
@@ -143,11 +151,17 @@ const ProfileModal: FC<ProfileModalProps> = ({ title, isOpen, onClose, profiles,
                     </div>
                     <i
                         role='presentation'
-                        className='material-icons updater'
+                        className={classNames(
+                            'material-icons',
+                            'updater',
+                            defaultSettings.endpoint === endpoint ? 'hidden' : ''
+                        )}
                         title={appLang?.modal?.endpoint_paste}
-                        onClick={() => {setProfileEndpoint(endpoint);}}
+                        onClick={() => {
+                            setProfileEndpoint(endpoint);
+                        }}
                     >
-                        &#xe14f;
+                        &#xea8e;
                     </i>
                 </div>
             </div>

--- a/src/renderer/pages/Scanner/index.tsx
+++ b/src/renderer/pages/Scanner/index.tsx
@@ -50,6 +50,7 @@ export default function Scanner() {
                 onClose={onCloseEndpointModal}
             />
             <ProfileModal
+                endpoint={endpoint || ''}
                 profiles={profiles}
                 setProfiles={setProfiles}
                 title={appLang?.modal?.profile_title}


### PR DESCRIPTION
Sometimes, when users scan and fetch endpoints from the repository, select one, and test it to find it works well, they might want to save that endpoint in their profiles for future use. Currently, they have to enter it manually (considering there is no context menu in this input field). With these changes, users can now use the "Paste Active Endpoint" button to automatically paste the active endpoint into the input field.

Additionally, I suggest adding a context menu to allow users to paste from other sources as well.
<img width="350" alt="ep" src="https://github.com/user-attachments/assets/1e73a50b-52b5-48d4-8d13-7cb357356a2c">
