### PR TITLE
Add total data usage breakdown and optimize code

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -542,9 +542,8 @@ html[data-bs-theme='dark'] .homeScreen .inFoot small {
 .homeScreen .inFoot .item {
     float: left;
     width: 100%;
-    margin: 5px 0;
+    margin: 5px 0 6px 0;
 }
-
 .homeScreen .inFoot .item img {
     float: left;
     width: 17px;
@@ -635,6 +634,9 @@ html[data-bs-theme='dark'] .shimmer {
     margin: 1px 0 5px 0;
     cursor: default;
 }
+.homeScreen .inFoot .item.speed .download {
+    float: left;
+}
 .homeScreen .inFoot .item.speed .upload {
     float: right;
     margin-right: 4px;
@@ -654,9 +656,68 @@ html[data-bs-theme='dark'] .shimmer {
     width: auto;
     cursor: default;
 }
+.homeScreen .inFoot .item.speed .isPing span {
+    cursor: pointer;
+}
 .homeScreen .inFoot .item.speed .download span small,
 .homeScreen .inFoot .item.speed .upload span small {
     cursor: default;
+}
+
+.homeScreen .inFoot .item .hasTooltip {
+    position: relative;
+}
+.homeScreen .inFoot .item .hasTooltip .isTooltip {
+    position: absolute;
+    content: '';
+    background: #fff;
+    border-radius: 5px;
+    color: #000;
+    min-width: 105px;
+    padding: 7px;
+    font-size: 12px;
+    font-weight: 200;
+    line-height: 17px;
+    bottom: 20px;
+    right: -3px;
+    transition: all 0.2s ease-in-out;
+    box-shadow: 0 -5px 15px rgba(0, 0, 0, 0.1);
+    opacity: 0;
+}
+[data-bs-theme='dark'] .homeScreen .inFoot .item .hasTooltip .isTooltip {
+    background: #01030a;
+    color: #c3c3c3;
+}
+.homeScreen .inFoot .item .hasTooltip:hover .isTooltip {
+    opacity: 1;
+}
+.homeScreen .inFoot .item .hasTooltip .isTooltip i {
+    float: left;
+    font-style: normal;
+    opacity: 0.3;
+    position: absolute;
+    left: 5px;
+    top: 5px;
+    margin: 0;
+}
+.homeScreen .inFoot .item .hasTooltip .isTooltip i.latest {
+    top: inherit;
+    bottom: 6px;
+}
+.homeScreen .inFoot .item .hasTooltip .isTooltip span {
+    direction: ltr;
+    float: right;
+    width: auto;
+    text-align: left;
+    overflow: inherit;
+    white-space: inherit;
+    text-overflow: inherit;
+    margin: 0;
+}
+.homeScreen .inFoot .item .hasTooltip .isTooltip .clearfix {
+    float: left;
+    width: 100%;
+    height: 4px;
 }
 
 .logPage .logText {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -481,7 +481,13 @@ if (!gotTheLock) {
                 const totalUsage = totalDownload + totalUpload;
 
                 if (mainWindow) {
-                    mainWindow.webContents.send('speed-stats', {currentDownload, currentUpload, totalDownload, totalUpload, totalUsage});
+                    mainWindow.webContents.send('speed-stats', {
+                        currentDownload,
+                        currentUpload,
+                        totalDownload,
+                        totalUpload,
+                        totalUsage
+                    });
                 }
             } catch (error) {
                 console.error('Error measuring network speed:', error);
@@ -493,7 +499,7 @@ if (!gotTheLock) {
             const mainInterface = networkStats[0];
             initialDownloadUsage = mainInterface.rx_bytes;
             initialUploadUsage = mainInterface.tx_bytes;
-        }
+        };
 
         const startNetworkSpeedMonitoring = () => {
             if (speedMonitorInterval) return;

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -13,8 +13,7 @@ export type Channels =
     | 'localization'
     | 'startup'
     | 'check-speed'
-    | 'download-speed'
-    | 'upload-speed';
+    | 'speed-stats';
 
 const electronHandler = {
     ipcRenderer: {

--- a/src/renderer/pages/Landing/LandingBody.tsx
+++ b/src/renderer/pages/Landing/LandingBody.tsx
@@ -117,12 +117,12 @@ const LandingBody: FC<LandingBodyProps> = ({
                                 {ipInfo.ip ? ipInfo.ip : '127.0.0.1'}
                             </span>
                         </div>
-                        <div
-                            role='presentation'
-                            className={classNames('item', 'speed')}
-                            onClick={handleOnClickPing}
-                        >
-                            <div className='download'>
+                        <div className={classNames('item', 'speed')}>
+                            <div
+                                className='download isPing'
+                                role='presentation'
+                                onClick={handleOnClickPing}
+                            >
                                 <i className='material-icons'>&#xebca;</i>
                                 <span className={ping === 0 ? 'shimmer' : ''}>
                                     {ping > 0
@@ -130,30 +130,33 @@ const LandingBody: FC<LandingBodyProps> = ({
                                         : 'timeout'}
                                 </span>
                             </div>
-                            <div
-                                className='upload'
-                                title={
-                                    'Download: ' +
-                                    speeds.totalDownload.value +
-                                    ' ' +
-                                    speeds.totalDownload.unit +
-                                    '\nUpload: ' +
-                                    speeds.totalUpload.value +
-                                    ' ' +
-                                    speeds.totalUpload.unit
-                                }
-                            >
+                            <div className={classNames('upload', 'hasTooltip')}>
                                 <i className='material-icons'>&#xe1af;</i>
-                                <span
-                                    className={
-                                        ping === 0 || speeds.totalUsage.unit === 'N/A'
-                                            ? 'shimmer'
-                                            : ''
-                                    }
-                                >
+                                <span className={speeds.totalUsage.unit === 'N/A' ? 'shimmer' : ''}>
                                     {speeds.totalUsage.value}{' '}
                                     <small>{speeds.totalUsage.unit}</small>
                                 </span>
+                                <div
+                                    className={classNames(
+                                        'isTooltip',
+                                        speeds.totalUpload.value === 'N/A' ||
+                                            speeds.totalDownload.value === 'N/A'
+                                            ? 'hidden'
+                                            : ''
+                                    )}
+                                >
+                                    <i className='material-icons'>&#xe5d8;</i>
+                                    <span>
+                                        {speeds.totalUpload.value}{' '}
+                                        <small>{speeds.totalUpload.unit}</small>
+                                    </span>
+                                    <div className='clearfix' />
+                                    <i className='material-icons latest'>&#xe5db;</i>
+                                    <span>
+                                        {speeds.totalDownload.value}{' '}
+                                        <small>{speeds.totalDownload.unit}</small>
+                                    </span>
+                                </div>
                             </div>
                         </div>
                         <div role='presentation' className={classNames('item', 'speed')}>

--- a/src/renderer/pages/Landing/LandingBody.tsx
+++ b/src/renderer/pages/Landing/LandingBody.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import { FC, FormEvent } from 'react';
 import { Swipe } from 'react-swipe-component';
 import { cfFlag } from '../../lib/cfFlag';
-import {SpeedStats} from "./useLanding";
+import { SpeedStats } from './useLanding';
 
 interface LandingBodyProps {
     appLang: any;
@@ -125,20 +125,34 @@ const LandingBody: FC<LandingBodyProps> = ({
                             <div className='download'>
                                 <i className='material-icons'>&#xebca;</i>
                                 <span className={ping === 0 ? 'shimmer' : ''}>
-                                {ping > 0
-                                    ? String(ping).replace(/\B(?=(\d{3})+(?!\d))/g, ',') + ' ms'
-                                    : 'timeout'}
+                                    {ping > 0
+                                        ? String(ping).replace(/\B(?=(\d{3})+(?!\d))/g, ',') + ' ms'
+                                        : 'timeout'}
                                 </span>
                             </div>
-                            <div className='upload'
-                                 title={'Download: ' + speeds.totalDownload.value + ' ' + speeds.totalDownload.unit + '\nUpload: ' + speeds.totalUpload.value + ' ' + speeds.totalUpload.unit}>
+                            <div
+                                className='upload'
+                                title={
+                                    'Download: ' +
+                                    speeds.totalDownload.value +
+                                    ' ' +
+                                    speeds.totalDownload.unit +
+                                    '\nUpload: ' +
+                                    speeds.totalUpload.value +
+                                    ' ' +
+                                    speeds.totalUpload.unit
+                                }
+                            >
                                 <i className='material-icons'>&#xe1af;</i>
                                 <span
                                     className={
-                                        ping === 0 || speeds.totalUsage.unit === 'N/A' ? 'shimmer' : ''
+                                        ping === 0 || speeds.totalUsage.unit === 'N/A'
+                                            ? 'shimmer'
+                                            : ''
                                     }
                                 >
-                                    {speeds.totalUsage.value} <small>{speeds.totalUsage.unit}</small>
+                                    {speeds.totalUsage.value}{' '}
+                                    <small>{speeds.totalUsage.unit}</small>
                                 </span>
                             </div>
                         </div>
@@ -152,17 +166,21 @@ const LandingBody: FC<LandingBodyProps> = ({
                                             : ''
                                     }
                                 >
-                                    {speeds.currentDownload.value} <small>{speeds.currentDownload.unit}</small>
+                                    {speeds.currentDownload.value}{' '}
+                                    <small>{speeds.currentDownload.unit}</small>
                                 </span>
                             </div>
                             <div className='upload'>
                                 <i className='material-icons'>&#xe2c3;</i>
                                 <span
                                     className={
-                                        ping === 0 || speeds.currentUpload.unit === 'N/A' ? 'shimmer' : ''
+                                        ping === 0 || speeds.currentUpload.unit === 'N/A'
+                                            ? 'shimmer'
+                                            : ''
                                     }
                                 >
-                                    {speeds.currentUpload.value} <small>{speeds.currentUpload.unit}</small>
+                                    {speeds.currentUpload.value}{' '}
+                                    <small>{speeds.currentUpload.unit}</small>
                                 </span>
                             </div>
                         </div>

--- a/src/renderer/pages/Landing/LandingBody.tsx
+++ b/src/renderer/pages/Landing/LandingBody.tsx
@@ -132,7 +132,13 @@ const LandingBody: FC<LandingBodyProps> = ({
                             </div>
                             <div className={classNames('upload', 'hasTooltip')}>
                                 <i className='material-icons'>&#xe1af;</i>
-                                <span className={speeds.totalUsage.unit === 'N/A' ? 'shimmer' : ''}>
+                                <span
+                                    className={
+                                        ping === 0 || speeds.totalUsage.unit === 'N/A'
+                                            ? 'shimmer'
+                                            : ''
+                                    }
+                                >
                                     {speeds.totalUsage.value}{' '}
                                     <small>{speeds.totalUsage.unit}</small>
                                 </span>

--- a/src/renderer/pages/Landing/LandingBody.tsx
+++ b/src/renderer/pages/Landing/LandingBody.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import { FC, FormEvent } from 'react';
 import { Swipe } from 'react-swipe-component';
 import { cfFlag } from '../../lib/cfFlag';
+import {SpeedStats} from "./useLanding";
 
 interface LandingBodyProps {
     appLang: any;
@@ -22,16 +23,7 @@ interface LandingBodyProps {
     handleOnClickPing: () => void;
     proxyStatus: string;
     appVersion: string;
-    speeds: {
-        download: {
-            value: string;
-            unit: string;
-        };
-        upload: {
-            value: string;
-            unit: string;
-        };
-    };
+    speeds: SpeedStats;
 }
 
 const LandingBody: FC<LandingBodyProps> = ({
@@ -127,37 +119,50 @@ const LandingBody: FC<LandingBodyProps> = ({
                         </div>
                         <div
                             role='presentation'
-                            className={classNames('item', 'ping')}
+                            className={classNames('item', 'speed')}
                             onClick={handleOnClickPing}
                         >
-                            <i className='material-icons'>&#xebca;</i>
-                            <span className={ping === 0 ? 'shimmer' : ''}>
+                            <div className='download'>
+                                <i className='material-icons'>&#xebca;</i>
+                                <span className={ping === 0 ? 'shimmer' : ''}>
                                 {ping > 0
                                     ? String(ping).replace(/\B(?=(\d{3})+(?!\d))/g, ',') + ' ms'
                                     : 'timeout'}
-                            </span>
+                                </span>
+                            </div>
+                            <div className='upload'
+                                 title={'Download: ' + speeds.totalDownload.value + ' ' + speeds.totalDownload.unit + '\nUpload: ' + speeds.totalUpload.value + ' ' + speeds.totalUpload.unit}>
+                                <i className='material-icons'>&#xe1af;</i>
+                                <span
+                                    className={
+                                        ping === 0 || speeds.totalUsage.unit === 'N/A' ? 'shimmer' : ''
+                                    }
+                                >
+                                    {speeds.totalUsage.value} <small>{speeds.totalUsage.unit}</small>
+                                </span>
+                            </div>
                         </div>
                         <div role='presentation' className={classNames('item', 'speed')}>
                             <div className='download'>
                                 <i className='material-icons'>&#xe2c0;</i>
                                 <span
                                     className={
-                                        ping === 0 || speeds.download.unit === 'N/A'
+                                        ping === 0 || speeds.currentDownload.unit === 'N/A'
                                             ? 'shimmer'
                                             : ''
                                     }
                                 >
-                                    {speeds.download.value} <small>{speeds.download.unit}</small>
+                                    {speeds.currentDownload.value} <small>{speeds.currentDownload.unit}</small>
                                 </span>
                             </div>
                             <div className='upload'>
                                 <i className='material-icons'>&#xe2c3;</i>
                                 <span
                                     className={
-                                        ping === 0 || speeds.upload.unit === 'N/A' ? 'shimmer' : ''
+                                        ping === 0 || speeds.currentUpload.unit === 'N/A' ? 'shimmer' : ''
                                     }
                                 >
-                                    {speeds.upload.value} <small>{speeds.upload.unit}</small>
+                                    {speeds.currentUpload.value} <small>{speeds.currentUpload.unit}</small>
                                 </span>
                             </div>
                         </div>

--- a/src/renderer/pages/Landing/useLanding.ts
+++ b/src/renderer/pages/Landing/useLanding.ts
@@ -19,11 +19,11 @@ let canCheckNewVer = true;
 let hasNewUpdate = false;
 
 export interface SpeedStats {
-    currentDownload: { value: string; unit: string; };
-    currentUpload: { value: string; unit: string; };
-    totalDownload: { value: string; unit: string; };
-    totalUpload: { value: string; unit: string; };
-    totalUsage: { value: string; unit: string; };
+    currentDownload: { value: string; unit: string };
+    currentUpload: { value: string; unit: string };
+    totalDownload: { value: string; unit: string };
+    totalUpload: { value: string; unit: string };
+    totalUsage: { value: string; unit: string };
 }
 
 export const defaultSpeedStats: SpeedStats = {
@@ -199,7 +199,7 @@ const useLanding = () => {
             }
         });
 
-        ipcRenderer.on('speed-stats', (event:any) => {
+        ipcRenderer.on('speed-stats', (event: any) => {
             const formattedCurrentDownload = formatSpeed(event?.currentDownload);
             const formattedCurrentUpload = formatSpeed(event?.currentUpload);
             const formattedTotalDownload = formatSpeed(event?.totalDownload);

--- a/src/renderer/pages/Landing/useLanding.ts
+++ b/src/renderer/pages/Landing/useLanding.ts
@@ -199,17 +199,12 @@ const useLanding = () => {
             }
         });
 
-        ipcRenderer.on('speed-stats', (event) => {
-            // @ts-ignore
-            const formattedCurrentDownload = formatSpeed(event.currentDownload);
-            // @ts-ignore
-            const formattedCurrentUpload = formatSpeed(event.currentUpload);
-            // @ts-ignore
-            const formattedTotalDownload = formatSpeed(event.totalDownload);
-            // @ts-ignore
-            const formattedTotalUpload = formatSpeed(event.totalUpload);
-            // @ts-ignore
-            const formattedTotalUsage = formatSpeed(event.totalUsage);
+        ipcRenderer.on('speed-stats', (event:any) => {
+            const formattedCurrentDownload = formatSpeed(event?.currentDownload);
+            const formattedCurrentUpload = formatSpeed(event?.currentUpload);
+            const formattedTotalDownload = formatSpeed(event?.totalDownload);
+            const formattedTotalUpload = formatSpeed(event?.totalUpload);
+            const formattedTotalUsage = formatSpeed(event?.totalUsage);
 
             setSpeeds((prevSpeeds) => ({
                 ...prevSpeeds,

--- a/src/renderer/pages/Landing/useLanding.ts
+++ b/src/renderer/pages/Landing/useLanding.ts
@@ -394,7 +394,7 @@ const useLanding = () => {
             }
         });
 
-        ipcRenderer.sendMessage('check-speed', isConnected && ipData);
+        ipcRenderer.sendMessage('check-speed', isConnected && proxyStatus !== 'none');
     }, [isLoading, isConnected, ipInfo, ipData, proxyStatus]);
 
     const handleMenuOnKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {

--- a/src/renderer/pages/Landing/useLanding.ts
+++ b/src/renderer/pages/Landing/useLanding.ts
@@ -18,6 +18,22 @@ let connectedToIrIPOnceDisplayed = false;
 let canCheckNewVer = true;
 let hasNewUpdate = false;
 
+export interface SpeedStats {
+    currentDownload: { value: string; unit: string; };
+    currentUpload: { value: string; unit: string; };
+    totalDownload: { value: string; unit: string; };
+    totalUpload: { value: string; unit: string; };
+    totalUsage: { value: string; unit: string; };
+}
+
+export const defaultSpeedStats: SpeedStats = {
+    currentDownload: { value: 'N/A', unit: 'N/A' },
+    currentUpload: { value: 'N/A', unit: 'N/A' },
+    totalDownload: { value: 'N/A', unit: 'N/A' },
+    totalUpload: { value: 'N/A', unit: 'N/A' },
+    totalUsage: { value: 'N/A', unit: 'N/A' }
+};
+
 const formatSpeed = (
     speed: number | null,
     precision: number = 2
@@ -70,10 +86,7 @@ const useLanding = () => {
     const [ping, setPing] = useState<number>(0);
     const [proxyMode, setProxyMode] = useState<string>('');
     const [shortcut, setShortcut] = useState<boolean>(false);
-    const [speeds, setSpeeds] = useState({
-        download: { value: 'N/A', unit: 'N/A' },
-        upload: { value: 'N/A', unit: 'N/A' }
-    });
+    const [speeds, setSpeeds] = useState<SpeedStats>(defaultSpeedStats);
 
     const navigate = useNavigate();
 
@@ -186,19 +199,25 @@ const useLanding = () => {
             }
         });
 
-        ipcRenderer.on('download-speed', function (event) {
-            const formattedDownloadSpeed = formatSpeed(event as number);
-            setSpeeds((prevSpeeds) => ({
-                ...prevSpeeds,
-                download: formattedDownloadSpeed
-            }));
-        });
+        ipcRenderer.on('speed-stats', (event) => {
+            // @ts-ignore
+            const formattedCurrentDownload = formatSpeed(event.currentDownload);
+            // @ts-ignore
+            const formattedCurrentUpload = formatSpeed(event.currentUpload);
+            // @ts-ignore
+            const formattedTotalDownload = formatSpeed(event.totalDownload);
+            // @ts-ignore
+            const formattedTotalUpload = formatSpeed(event.totalUpload);
+            // @ts-ignore
+            const formattedTotalUsage = formatSpeed(event.totalUsage);
 
-        ipcRenderer.on('upload-speed', function (event) {
-            const formattedUploadSpeed = formatSpeed(event as number);
             setSpeeds((prevSpeeds) => ({
                 ...prevSpeeds,
-                upload: formattedUploadSpeed
+                currentDownload: formattedCurrentDownload,
+                currentUpload: formattedCurrentUpload,
+                totalDownload: formattedTotalDownload,
+                totalUpload: formattedTotalUpload,
+                totalUsage: formattedTotalUsage
             }));
         });
 


### PR DESCRIPTION
This PR implements the following changes:

1. Add display of total data transferred during the connection session
2. Include breakdown of total upload and download stats
3. Optimize the existing code

Notes:
- Temporarily using 'speed', 'upload', and 'download' classes for styling to position information appropriately. Final styling adjustments can be made as needed.
- The current implementation of showing total upload and download as a tooltip may not be ideal:
  a) It requires focus on the application window
  b) The tooltip closes and reopens on each value change
  Please feel free to adjust this display method for better user experience.

All requested features from the previous PR comments have now been implemented.

<img width="300" alt="dt" src="https://github.com/user-attachments/assets/a09f5a10-a5c3-436a-9253-7ab3c5141c89">

