### PR TITLE
Improve Network Speed and Data Usage Calculation by Targeting Proxy Interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "oblivion-desktop",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "oblivion-desktop",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "hasInstallScript": true,
             "license": "Restrictive",
             "dependencies": {
@@ -28,7 +28,7 @@
                 "react-swipe-component": "^3.0.0",
                 "regedit": "^5.1.3",
                 "serve-handler": "^6.1.5",
-                "systeminformation": "^5.23.3",
+                "systeminformation": "^5.23.4",
                 "tree-kill": "^1.2.2",
                 "zustand": "^4.5.2"
             },
@@ -16409,9 +16409,9 @@
             }
         },
         "node_modules/systeminformation": {
-            "version": "5.23.3",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.23.3.tgz",
-            "integrity": "sha512-jnj0GjvWQaMLz7eSuYjZLim+pyZ6bjClwTz+YLoOT50DSJdWSEnISOCnq35IzoEfRa2rX9wdwlaQ/LxUu6RMFQ==",
+            "version": "5.23.4",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.23.4.tgz",
+            "integrity": "sha512-mD2R9xnOzKOOmIVtxekosf/ghOE/DGLqAPmsEgQMWJK0pMKxBtX19riz1Ss0tN4omcfS2FQ2RDJ4lkxgADxIPw==",
             "os": [
                 "darwin",
                 "linux",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "react-swipe-component": "^3.0.0",
         "regedit": "^5.1.3",
         "serve-handler": "^6.1.5",
-        "systeminformation": "^5.23.3",
+        "systeminformation": "^5.23.4",
         "tree-kill": "^1.2.2",
         "zustand": "^4.5.2"
     },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -490,7 +490,7 @@ if (!gotTheLock) {
             try {
                 const interfaces = await networkInterfaces();
                 const loopbackInterface = Object.values(interfaces).find(
-                    (iface) => iface.ip4 === '127.0.0.1'
+                    (iface) => iface.ip4 === defaultSettings.hostIP
                 );
 
                 if (loopbackInterface) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -29,7 +29,7 @@ import settings from 'electron-settings';
 import log from 'electron-log';
 //import { autoUpdater } from 'electron-updater';
 //import packageJsonData from '../../package.json';
-import { networkStats, powerShellStart } from 'systeminformation';
+import { networkInterfaces, networkStats, powerShellStart } from 'systeminformation';
 import MenuBuilder from './menu';
 import { exitTheApp, isDev } from './lib/utils';
 import { openDevToolsByDefault, useCustomWindowXY } from './dxConfig';
@@ -486,11 +486,27 @@ if (!gotTheLock) {
             );
         };
 
-        const measureNetworkSpeed = () => {
+        const findLoopbackInterface = async () => {
+            try {
+                const interfaces = await networkInterfaces();
+                const loopbackInterface = Object.values(interfaces).find(
+                    (iface) => iface.ip4 === '127.0.0.1'
+                );
+
+                if (loopbackInterface) {
+                    return loopbackInterface.iface;
+                }
+            } catch (error) {
+                console.error('Error fetching network interfaces:', error);
+            }
+            return '';
+        };
+
+        const measureNetworkSpeed = (loopbackInterface: string) => {
             if (isSpeedMonitoring) return;
 
             isSpeedMonitoring = true;
-            networkStats()
+            networkStats(loopbackInterface)
                 .then((data) => {
                     const mainInterface = data[0];
                     if (!isUsageInitialized) {
@@ -522,12 +538,13 @@ if (!gotTheLock) {
                 });
         };
 
-        const startNetworkSpeedMonitoring = () => {
+        const startNetworkSpeedMonitoring = async () => {
             if (speedMonitorInterval) return;
             if (process.platform === 'win32') {
                 powerShellStart();
             }
-            speedMonitorInterval = setInterval(measureNetworkSpeed, 2000);
+            const loopbackInterface = await findLoopbackInterface();
+            speedMonitorInterval = setInterval(() => measureNetworkSpeed(loopbackInterface), 2000);
         };
 
         const stopNetworkSpeedMonitoring = () => {


### PR DESCRIPTION
This update refines the network speed and data usage calculations by specifically targeting the network interface associated with the proxy at 127.0.0.1. Previously, the application measured the speed and usage of the entire system, which could be inaccurate if some applications did not use the proxy.

Now, the code first attempts to find the network interface linked to the loopback address 127.0.0.1. If found, the calculations will be confined to that specific interface, ensuring more accurate results. If no such interface is found, the code will fall back to measuring the entire system's network activity, maintaining the previous behavior.

This enhancement should provide more precise monitoring for applications that utilize the proxy, especially in environments where not all traffic routes through the proxy.

Note: This update has been tested on macOS (and likely works on Linux as well). However, since I am not a Windows user, I recommend conducting thorough tests on a Windows system before merging.