### PR TITLE
Improve Connection Setup for Sing-Box

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -67,7 +67,7 @@ export const defaultSettings = {
     dataUsage: false,
     asn: 'UNK',
     closeSingBox: true,
-    closeHelper: true,
+    closeHelper: false,
     singBoxMTU: 9000,
     singBoxGeoBlock: false
 };

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,4 +1,4 @@
 export const wpVersion = '1.2.4';
 export const sbVersion = '1.9.7';
-export const helperVersion = '1.0.4';
+export const helperVersion = '1.0.5';
 export const geoDBs = ['geoip.db', 'geosite.db', 'security.db', 'security-ip.db'];

--- a/src/main/lib/sbConfig.ts
+++ b/src/main/lib/sbConfig.ts
@@ -4,7 +4,6 @@ import { sbConfigPath } from '../ipcListeners/wp';
 
 export function createSbConfig(
     socksPort: number,
-    endpointPorts: number[],
     mtu: number,
     geoBlock: boolean,
     geoIp: string,
@@ -64,13 +63,8 @@ export function createSbConfig(
         route: {
             rules: [
                 {
-                    port: endpointPorts,
                     network: 'udp',
                     outbound: 'direct-out'
-                },
-                {
-                    network: 'udp',
-                    outbound: 'block-out'
                 },
                 {
                     ip_is_private: true,


### PR DESCRIPTION
This update optimizes the connection process for the Sing-Box tunnel, ensuring faster initialization by running Sing-Box concurrently with Warp-Plus. Previously, Sing-Box would start after receiving the `successMessage` from Warp-Plus. Now, `checkConnectionStatus` is triggered upon receiving the `successMessage` from Warp-Plus, allowing more efficient handling of connection states.

Changes:
1. **Simultaneous Start**: Sing-Box now starts concurrently with Warp-Plus, improving connection speed.
2. **Endpoint Port Extraction**: Disabled extraction of UDP endpoint ports and removed them from the Sing-Box configuration. All UDP traffic is now routed directly (`DIRECT`) in the Sing-Box config.
   - Previously, `extractPortsFromEndpoints` would extract these ports and apply them as `DIRECT` in Sing-Box while blocking others. However, since Sing-Box now starts before receiving the `endpointMessage` from Warp-Plus, these ports are no longer available for extraction.
3. **Helper Version Update**: Updated Oblivion-Helper to version `1.0.5`.
4. **Config Change**: Set the default value of `closeHelper` to `false` in the default settings.

These improvements streamline the process and enhance the overall performance of the Sing-Box and Warp-Plus integration.