### PR TITLE
feat(window): add proxy modes to try icon context menu

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -74,6 +74,7 @@ interface WindowState {
     connectionStatus: string;
     trayMenuEvent?: IpcMainEvent;
     userLang: string;
+    proxyMode: string | null;
     appLang: ReturnType<typeof getTranslate>;
 }
 
@@ -83,6 +84,7 @@ class OblivionDesktop {
         appIcon: null,
         connectionStatus: 'disconnected',
         userLang: 'en',
+        proxyMode: null,
         appLang: getTranslate('en')
     };
 
@@ -114,6 +116,7 @@ class OblivionDesktop {
     private async setupInitialConfiguration(): Promise<void> {
         devPlayground();
         log.info('Creating new od instance...');
+        this.state.proxyMode = await settings.get('proxyMode') as string;
         await this.handleVersionCheck();
         this.copyRequiredFiles();
     }
@@ -744,12 +747,32 @@ class OblivionDesktop {
         }
     }
 
+
     private createTrayMenuTemplate(): MenuItemConstructorOptions[] {
         const connectLabel = this.getConnectionLabel();
         const canToggleConnection = !(
             this.state.connectionStatus === 'disconnecting' ||
             this.state.connectionStatus === 'connecting'
         );
+
+
+        const changeProxyMode = (value: string)=> {
+            if(!this.state.mainWindow) return;
+            this.state.mainWindow.webContents.send('change-proxy-mode', value)
+            this.state.proxyMode = value;
+            this.updateTrayMenu()
+        }
+
+      const proxyModeLabel = (mode: string): string => {
+        const labels: Record<string, string> = {
+          system: 'System proxy',
+          tun: 'Tun',
+        };
+
+        const label = labels[mode] ?? 'None';
+        const prefix = this.state.proxyMode === mode ? '✓  ' : '   ';
+        return `${prefix}${label}`;
+      };
 
         return [
             {
@@ -771,6 +794,26 @@ class OblivionDesktop {
                             : 'disconnecting';
                     this.updateTrayMenu();
                 }
+            },
+            {
+                label: this.state.appLang.settings.proxy_mode,
+                submenu: [
+                    {
+                        label: proxyModeLabel('none'),
+                        type: 'normal',
+                        click: () => changeProxyMode('none')
+                    },
+                    {
+                        label: proxyModeLabel('system'),
+                        type: 'normal',
+                        click: () => changeProxyMode('system')
+                    },
+                    {
+                        label: proxyModeLabel('tun'),
+                        type: 'normal',
+                        click: () => changeProxyMode('tun')
+                    }
+                ]
             },
             {
                 label: this.state.appLang.systemTray.settings,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -116,7 +116,7 @@ class OblivionDesktop {
     private async setupInitialConfiguration(): Promise<void> {
         devPlayground();
         log.info('Creating new od instance...');
-        this.state.proxyMode = await settings.get('proxyMode') as string;
+        this.state.proxyMode = (await settings.get('proxyMode')) as string;
         await this.handleVersionCheck();
         this.copyRequiredFiles();
     }
@@ -747,7 +747,6 @@ class OblivionDesktop {
         }
     }
 
-
     private createTrayMenuTemplate(): MenuItemConstructorOptions[] {
         const connectLabel = this.getConnectionLabel();
         const canToggleConnection = !(
@@ -755,24 +754,23 @@ class OblivionDesktop {
             this.state.connectionStatus === 'connecting'
         );
 
-
-        const changeProxyMode = (value: string)=> {
-            if(!this.state.mainWindow) return;
-            this.state.mainWindow.webContents.send('change-proxy-mode', value)
+        const changeProxyMode = (value: string) => {
+            if (!this.state.mainWindow) return;
+            this.state.mainWindow.webContents.send('change-proxy-mode', value);
             this.state.proxyMode = value;
-            this.updateTrayMenu()
-        }
-
-      const proxyModeLabel = (mode: string): string => {
-        const labels: Record<string, string> = {
-          system: 'System proxy',
-          tun: 'Tun',
+            this.updateTrayMenu();
         };
 
-        const label = labels[mode] ?? 'None';
-        const prefix = this.state.proxyMode === mode ? '✓  ' : '   ';
-        return `${prefix}${label}`;
-      };
+        const proxyModeLabel = (mode: string): string => {
+            const labels: Record<string, string> = {
+                system: 'System proxy',
+                tun: 'Tun'
+            };
+
+            const label = labels[mode] ?? 'None';
+            const prefix = this.state.proxyMode === mode ? '✓  ' : '   ';
+            return `${prefix}${label}`;
+        };
 
         return [
             {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -795,6 +795,7 @@ class OblivionDesktop {
             },
             {
                 label: this.state.appLang.settings.proxy_mode,
+                enabled: this.state.connectionStatus === 'disconnected',
                 submenu: [
                     {
                         label: proxyModeLabel('none'),
@@ -813,6 +814,7 @@ class OblivionDesktop {
                     }
                 ]
             },
+            { label: '', type: 'separator' },
             {
                 label: this.state.appLang.systemTray.settings,
                 submenu: [

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -17,7 +17,8 @@ export type Channels =
     | 'process-url'
     | 'download-update'
     | 'download-progress'
-    | 'local-ips';
+    | 'local-ips'
+    | 'change-proxy-mode';
 
 const electronHandler = {
     ipcRenderer: {

--- a/src/renderer/context/GlobalContext.tsx
+++ b/src/renderer/context/GlobalContext.tsx
@@ -1,6 +1,6 @@
-import React, {createContext, useContext, useEffect} from 'react';
-import {ipcRenderer} from "../lib/utils";
-import useOptions from "../pages/Network/useOptions";
+import React, { createContext, useContext, useEffect } from 'react';
+import { ipcRenderer } from '../lib/utils';
+import useOptions from '../pages/Network/useOptions';
 
 const GlobalContext = createContext<ReturnType<typeof useOptions> | null>(null);
 
@@ -15,11 +15,7 @@ export const GlobalProvider = ({ children }: { children: React.ReactNode }) => {
             ipcRenderer.removeAllListeners('change-proxy-mode');
         };
     }, []);
-    return (
-        <GlobalContext.Provider value={options}>
-            {children}
-        </GlobalContext.Provider>
-    );
+    return <GlobalContext.Provider value={options}>{children}</GlobalContext.Provider>;
 };
 
 export const useOptionsContext = () => {

--- a/src/renderer/context/GlobalContext.tsx
+++ b/src/renderer/context/GlobalContext.tsx
@@ -1,0 +1,31 @@
+import React, {createContext, useContext, useEffect} from 'react';
+import {ipcRenderer} from "../lib/utils";
+import useOptions from "../pages/Network/useOptions";
+
+const GlobalContext = createContext<ReturnType<typeof useOptions> | null>(null);
+
+export const GlobalProvider = ({ children }: { children: React.ReactNode }) => {
+    const options = useOptions();
+    useEffect(() => {
+        ipcRenderer.on('change-proxy-mode', (value: string) => {
+            options.onChangeProxyMode(value);
+        });
+
+        return () => {
+            ipcRenderer.removeAllListeners('change-proxy-mode');
+        };
+    }, []);
+    return (
+        <GlobalContext.Provider value={options}>
+            {children}
+        </GlobalContext.Provider>
+    );
+};
+
+export const useOptionsContext = () => {
+    const context = useContext(GlobalContext);
+    if (!context) {
+        throw new Error('useOptionsContext must be used within an <OptionsProvider>');
+    }
+    return context;
+};

--- a/src/renderer/context/GlobalContext.tsx
+++ b/src/renderer/context/GlobalContext.tsx
@@ -7,7 +7,7 @@ const GlobalContext = createContext<ReturnType<typeof useOptions> | null>(null);
 export const GlobalProvider = ({ children }: { children: React.ReactNode }) => {
     const options = useOptions();
     useEffect(() => {
-        ipcRenderer.on('change-proxy-mode', (value: string) => {
+        ipcRenderer.on('change-proxy-mode', (value: any) => {
             options.onChangeProxyMode(value);
         });
 

--- a/src/renderer/pages/Network/index.tsx
+++ b/src/renderer/pages/Network/index.tsx
@@ -4,11 +4,11 @@ import Nav from '../../components/Nav';
 import PortModal from '../../components/Modal/Port';
 import Tabs from '../../components/Tabs';
 import RoutingRulesModal from '../../components/Modal/RoutingRules';
-import useOptions from './useOptions';
 import Dropdown from '../../components/Dropdown';
 import { dnsServers } from '../../../defaultSettings';
 //import { platform } from '../../lib/utils';
 import DnsModal from '../../components/Modal/DNS';
+import {useOptionsContext} from "../../context/GlobalContext";
 
 const proxyModes = [
     {
@@ -25,7 +25,7 @@ const proxyModes = [
     }
 ];
 
-export default function Options() {
+export default function Network() {
     const {
         countRoutingRules,
         dns,
@@ -63,7 +63,7 @@ export default function Options() {
         setCustomDns,
         setShowDnsModal,
         checkingLocalIp
-    } = useOptions();
+    } = useOptionsContext();
     if (
         typeof ipData === 'undefined' ||
         typeof port === 'undefined' ||

--- a/src/renderer/pages/Network/index.tsx
+++ b/src/renderer/pages/Network/index.tsx
@@ -8,7 +8,7 @@ import Dropdown from '../../components/Dropdown';
 import { dnsServers } from '../../../defaultSettings';
 //import { platform } from '../../lib/utils';
 import DnsModal from '../../components/Modal/DNS';
-import {useOptionsContext} from "../../context/GlobalContext";
+import { useOptionsContext } from '../../context/GlobalContext';
 
 const proxyModes = [
     {

--- a/src/renderer/pages/Network/useOptions.ts
+++ b/src/renderer/pages/Network/useOptions.ts
@@ -158,17 +158,22 @@ const useOptions = () => {
     }, []);
 
     const onChangeProxyMode = useCallback(
-        (event: ChangeEvent<HTMLSelectElement>) => {
-            setProxyMode(event.target.value);
-            settings.set('proxyMode', event.target.value);
-            settingsHaveChangedToast({ ...{ isConnected, isLoading, appLang } });
-            setTimeout(function () {
-                if (event.target.value === 'none') {
+        (input: ChangeEvent<HTMLSelectElement> | string) => {
+            const value = typeof input === 'string' ? input : input.target.value;
+
+            if(proxyMode === value) return
+
+            setProxyMode(value);
+            settings.set('proxyMode', value);
+            settingsHaveChangedToast({ isConnected, isLoading, appLang });
+
+            setTimeout(() => {
+                if (value === 'none') {
                     setIpData(false);
                     settings.set('ipData', false);
                     setDataUsage(false);
                     settings.set('dataUsage', false);
-                } else if (event.target.value === 'tun') {
+                } else if (value === 'tun') {
                     //setHostIp(networkList[0].value);
                     /*if (method === 'psiphon') {
                         settings.set('method', 'gool');
@@ -179,6 +184,7 @@ const useOptions = () => {
         },
         [isConnected, isLoading, appLang]
     );
+
 
     const onChangeDNS = useCallback(
         (event: ChangeEvent<HTMLSelectElement>) => {

--- a/src/renderer/pages/Network/useOptions.ts
+++ b/src/renderer/pages/Network/useOptions.ts
@@ -161,7 +161,7 @@ const useOptions = () => {
         (input: ChangeEvent<HTMLSelectElement> | string) => {
             const value = typeof input === 'string' ? input : input.target.value;
 
-            if(proxyMode === value) return
+            if (proxyMode === value) return;
 
             setProxyMode(value);
             settings.set('proxyMode', value);
@@ -184,7 +184,6 @@ const useOptions = () => {
         },
         [isConnected, isLoading, appLang]
     );
-
 
     const onChangeDNS = useCallback(
         (event: ChangeEvent<HTMLSelectElement>) => {

--- a/src/renderer/routes/index.tsx
+++ b/src/renderer/routes/index.tsx
@@ -1,5 +1,4 @@
 import { Route, Routes } from 'react-router-dom';
-
 import Landing from '../pages/Landing';
 import Settings from '../pages/Settings';
 import Options from '../pages/Options';
@@ -9,20 +8,23 @@ import Scanner from '../pages/Scanner';
 import Network from '../pages/Network';
 import Speed from '../pages/SpeedTest';
 import SingBox from '../pages/SingBox';
+import {GlobalProvider} from "../context/GlobalContext";
 
 const AppRoutes = () => {
     return (
-        <Routes>
-            <Route path='/' element={<Landing />} />
-            <Route path='/settings' element={<Settings />} />
-            <Route path='/options' element={<Options />} />
-            <Route path='/about' element={<About />} />
-            <Route path='/debug' element={<Debug />} />
-            <Route path='/scanner' element={<Scanner />} />
-            <Route path='/network' element={<Network />} />
-            <Route path='/speed' element={<Speed />} />
-            <Route path='/singBox' element={<SingBox />} />
-        </Routes>
+        <GlobalProvider>
+            <Routes>
+                <Route path='/' element={<Landing />} />
+                <Route path='/settings' element={<Settings />} />
+                <Route path='/options' element={<Options />} />
+                <Route path='/about' element={<About />} />
+                <Route path='/debug' element={<Debug />} />
+                <Route path='/scanner' element={<Scanner />} />
+                <Route path='/network' element={<Network />} />
+                <Route path='/speed' element={<Speed />} />
+                <Route path='/singBox' element={<SingBox />} />
+            </Routes>
+        </GlobalProvider>
     );
 };
 

--- a/src/renderer/routes/index.tsx
+++ b/src/renderer/routes/index.tsx
@@ -8,7 +8,7 @@ import Scanner from '../pages/Scanner';
 import Network from '../pages/Network';
 import Speed from '../pages/SpeedTest';
 import SingBox from '../pages/SingBox';
-import {GlobalProvider} from "../context/GlobalContext";
+import { GlobalProvider } from '../context/GlobalContext';
 
 const AppRoutes = () => {
     return (


### PR DESCRIPTION
### Change Description

Dear friend,

Automatically reconnecting the proxy after any configuration changes would significantly improve the overall user experience.
Wishing you all the best.

Additionally, proxy mode options have been added to the context menu of the program icon in the taskbar.


### Checklist

- [ ] Code has been tested.
    - [ ] Windows 10
    - [ ] Windows 11
    - [ ] macOS
    - [ ] Linux
- [ ] Relevant documentation has been updated.

