### PR TITLE
Prevent potential ui bugs

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -482,7 +482,7 @@ class OblivionDesktop {
     }
 
     private async checkForUpdates(downloadUpdate?: boolean) {
-        if ( isDev() ) return;
+        if (isDev()) return;
         if (this.state.isCheckingForUpdates) return;
         try {
             this.state.isCheckingForUpdates = true;

--- a/src/renderer/pages/Landing/useLanding.ts
+++ b/src/renderer/pages/Landing/useLanding.ts
@@ -67,8 +67,10 @@ const useLanding = () => {
     });
 
     const [drawerIsOpen, setDrawerIsOpen] = useState<boolean>(false);
-    const toggleDrawer = () => {
-        setDrawerIsOpen((prevState) => !prevState);
+    const toggleDrawer = (newState?: boolean) => {
+        const isFull = window?.innerWidth > 1049;
+        if (!isFull)
+            setDrawerIsOpen(typeof newState == 'boolean' ? newState : (prevState) => !prevState);
     };
 
     const [lang, setLang] = useState<string>();
@@ -230,7 +232,7 @@ const useLanding = () => {
         cachedIpInfo = null;
 
         onEscapeKeyPressed(() => {
-            setDrawerIsOpen(false);
+            toggleDrawer(false);
         });
         toast.remove('COPIED');
 
@@ -336,10 +338,10 @@ const useLanding = () => {
         ipcRenderer.on('new-update', (HasNewUpdate: any) => {
             setIsCheckingForUpdates(false);
             setHasNewUpdate(HasNewUpdate);
-            handleResize();
         });
 
         ipcRenderer.on('download-progress', (args: any) => {
+            if (downloadProgress.percent == 0) toggleDrawer(false);
             setDownloadProgress(args);
         });
 


### PR DESCRIPTION
### Change Description

Unfortunately #1141 is merged so i had to create a new PR.

Right now pressing the escape button could lead to a full screen  landing page without a drawer.

This pull request Prevents potential UI bugs for now and hopefully in the future simply by making sure the screen isn't full screen before closing the drawer.

Also i changed the way update system handles closing drawer so drawer won't be closed unexpectedly simply because there was a check for update event running in the background.

i keep this PR as a draft until the changes are approved so i won't have to create a new one.

### Checklist

- [ ] Code has been tested.
    - [ ] Windows 10
    - [ ] Windows 11
    - [ ] macOS
    - [ ] Linux
- [ ] Relevant documentation has been updated.

### Related Links

